### PR TITLE
Replaces moment dependency with native date handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Next
+* (Change) Replaces moment.js with native date handling.
 
 ### 0.5.2 (2020-10-20)
 * (Bugfix) Correct HTML for snippets (bug introduced in `0.5.0`)

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -4,7 +4,6 @@ const commandLineArgs = require('command-line-args');
 const fs = require('fs-extra');
 const signale = require('signale');
 const _ = require('lodash');
-const moment = require('moment');
 const { rootDir } = require('./root-dir');
 
 let options = {};
@@ -224,7 +223,7 @@ log('note', 'Reading manifest');
 
 if (!fs.pathExistsSync(manifestFile)) {
   log('info', 'Creating new manifest at %s', manifestFile);
-  fs.outputJsonSync(manifestFile, { version: 1, timestamp: moment().toISOString(), files: {} }, manifestOptions);
+  fs.outputJsonSync(manifestFile, { version: 1, timestamp: new Date().toISOString(), files: {} }, manifestOptions);
 }
 
 const manifest = fs.readJsonSync(manifestFile);

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra');
 const path = require('path');
-const moment = require('moment');
 const md5 = require('md5');
 const jsdiff = require('diff');
 const {
@@ -65,7 +64,7 @@ async function writeFile(name, contents) {
  * @returns {void}
  */
 function updateManifest(contents) {
-  manifest.timestamp = moment().toISOString();
+  manifest.timestamp = new Date().toISOString();
 
   if (!options.dryRun && !options.ignoreManifest) {
     fs.outputJsonSync(options.manifestFile, contents, manifestOptions, () => log('success', 'Wrote manifest'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1243,11 +1243,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
-    "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "js-beautify": "~1.11.0",
     "lodash": "~4.17.15",
     "md5": "~2.2.1",
-    "moment": "~2.26.0",
     "puppeteer": "^3.3.0",
     "signale": "~1.4.0",
     "vue-template-compiler": "~2.6.11"


### PR DESCRIPTION
This PR replaces moment.js date handling with a native solution, because moment js did conflict with Pikaday usage.